### PR TITLE
Update Carthage and Pod samples to 4.17.0

### DIFF
--- a/Carthage Sample/Cartfile.resolved
+++ b/Carthage Sample/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ContentSquare/CS_iOS_SDK" "4.15.1"
-github "apple/swift-protobuf" "1.19.0"
+github "ContentSquare/CS_iOS_SDK" "4.17.0"
+github "apple/swift-protobuf" "1.20.2"

--- a/Pod Sample/Podfile.lock
+++ b/Pod Sample/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - CS_iOS_SDK (4.15.1):
+  - CS_iOS_SDK (4.17.0):
     - SwiftProtobuf (~> 1.0)
-  - SwiftProtobuf (1.19.0)
+  - SwiftProtobuf (1.20.2)
 
 DEPENDENCIES:
   - CS_iOS_SDK
@@ -12,8 +12,8 @@ SPEC REPOS:
     - SwiftProtobuf
 
 SPEC CHECKSUMS:
-  CS_iOS_SDK: 71cc98819067af58512ba04c543dc24c93cf32e2
-  SwiftProtobuf: 6ef3f0e422ef90d6605ca20b21a94f6c1324d6b3
+  CS_iOS_SDK: ea609c569916887afa37e543eb5124eede0727f7
+  SwiftProtobuf: 9f458aaa7844a2fc0b910053e66578bc4e2da9c1
 
 PODFILE CHECKSUM: 3e18f271485b4f2e24e847a86e9e671bbc4c4180
 


### PR DESCRIPTION
if you open it, SPM should update automatically (or you can force it manually)
Static framework is not tracked, you need to download it and install it in your repo.

All samples work for me, except the static integration, I have the following message: 
```
2022-10-25 10:49:27.309868+0200 static-framework-sample-app[96642:11336757] CSLIB ℹ️ Info: ⚠️ Contentsquare SDK cannot execute operation because it hasn't been started.
2022-10-25 10:49:31.638100+0200 static-framework-sample-app[96642:11336757] CSLIB ℹ️ Info: ⚠️ Contentsquare SDK cannot execute operation because it hasn't been started.
```